### PR TITLE
chore: Sort Index Posts

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -32,7 +32,7 @@ export default function Index({ data: { allMdx } }) {
 
 export const recentPostQuery = graphql`
   query RecentPostsQuery {
-    allMdx(limit: 5) {
+    allMdx(limit: 5, sort: { fields: frontmatter___date, order: DESC }) {
       edges {
         node {
           fields {


### PR DESCRIPTION
* Index 포스트의 순서를 frontmatter date의 역순으로 정렬합니다.